### PR TITLE
Collect all statistics and optimize checks

### DIFF
--- a/src/reflect/scala/reflect/internal/util/Statistics.scala
+++ b/src/reflect/scala/reflect/internal/util/Statistics.scala
@@ -256,7 +256,7 @@ quant)
    *
    *  to remove all Statistics code from build
    */
-  final val canEnable = _enabled
+  final def canEnable = _enabled
 
   /** replace with
    *


### PR DESCRIPTION
References: scala/scala-dev#149.

This PR does the two following things, all in the domain of statistics:

1. It allows the collection of all the statistics (before, we were only
   reporting on a very narrow set of the available statistics). This is
   achieved by turning `canEnable` into a `def` instead of `val`. Previous
   history: ebb719f#diff-438d9e5ac0dd1965aabd4776e1ee70eaR246/
2. It adds a mechanism to remove the overhead of checking for statistics
   in the common case (where statistics are disabled). It does so by
   reusing a mechanism proposed by Rémi Forax and brought to my
   attention by @retronym (more here: scala/scala-dev#149).

There is one pending issues with this PR, which hasn't been solved yet:

* How do we keep this implementation runtime-agnostic, allowing
  compilers like Scalajs and Scala.native to default to an inefficient
  implementation?

I don't know how to do this (or how these compilers are replacing JVM-specific
implementations), so I would appreciate insights from @sjrd and @densh.

In the future, I could look into ways of expanding this implementation to all
our flag checking infrastructure, which is what the referenced ticket on the
top is about. However, I'd prefer to do this in a separate PR if possible. For
now, I wanted to create a very small change to see the prior results.

This PR is work-in-progress and I've just opened it to check the
performance penalty of my changes. Afterwards, I would like to detect
what's the performance penalty of having statistics enabled by default,
I'm sure we can draw interesting results from there.