### PR TITLE
Reify Tasty Names, which allows to reduce coupling

### DIFF
--- a/src/compiler/scala/tools/nsc/tasty/ScalacUnpickler.scala
+++ b/src/compiler/scala/tools/nsc/tasty/ScalacUnpickler.scala
@@ -5,28 +5,15 @@ import scala.reflect.io.AbstractFile
 import TastyRefs.NameRef
 import scala.util.control.NonFatal
 import scala.reflect.internal.SymbolTable
+import scala.tools.nsc.tasty.Names.TastyName
 
 object ScalacUnpickler {
 
   final class TreeSectionUnpickler[SymbolTable <: reflect.internal.SymbolTable](implicit symbolTable: SymbolTable)
   extends SectionUnpickler[TreeUnpickler { val symbolTable: SymbolTable }]("ASTs") { self =>
-    def unpickle(reader: TastyReader, nameTable: TastyNameTable with TastyUniverse): TreeUnpickler { val symbolTable: SymbolTable } =
-      new TreeUnpickler(reader, None, None, Seq.empty) {
-
-        assert(nameTable.symbolTable `eq` self.symbolTable, "Unsafe creation of name ref mapper without shared underlying symbol table")
-
-        final val symbolTable: SymbolTable =
-          self.symbolTable
-
-        final val nameAtRef: NameRef => symbolTable.TermName =
-          nameTable.nameAtRef.asInstanceOf[NameRef => symbolTable.TermName]
-
-        final val signedNameAtRef: NameRef => Either[SigName, symbolTable.TermName] =
-          nameTable.signedNameAtRef.asInstanceOf[NameRef => Either[SigName, symbolTable.TermName]]
-
-        final val moduleRefs: NameRef => Boolean =
-          nameTable.moduleRefs.asInstanceOf[NameRef => Boolean]
-
+    def unpickle(reader: TastyReader, nameAtRef: NameRef => TastyName ): TreeUnpickler { val symbolTable: SymbolTable } =
+      new TreeUnpickler(reader, nameAtRef, None, None, Seq.empty) {
+        final val symbolTable: SymbolTable = self.symbolTable
       }
   }
 }

--- a/src/compiler/scala/tools/nsc/tasty/Signature.scala
+++ b/src/compiler/scala/tools/nsc/tasty/Signature.scala
@@ -2,20 +2,33 @@ package scala.tools.nsc.tasty
 
 import scala.reflect.internal.SymbolTable
 import scala.tools.nsc.tasty.Signature.ParamSig
+import scala.tools.nsc.tasty.Signature.MethodSignature
+import scala.tools.nsc.tasty.Signature.NotAMethod
 
-sealed trait Signature[+T] {
-  def show: String
+sealed trait Signature[+T] { self =>
+
+  final def show: String = mergeShow(new StringBuilder(30)).toString
+
+  final def mergeShow(sb: StringBuilder): StringBuilder = self match {
+    case MethodSignature(paramsSig, resSig) =>
+      paramsSig.map(_.merge).addString(sb, "(", ",", ")").append(resSig)
+
+    case NotAMethod => sb.append("<nosig>")
+  }
+
+  final def map[U](f: T => U): Signature[U] = self match {
+    case MethodSignature(paramsSig, resSig) => MethodSignature(paramsSig.map(_.map(f)), f(resSig))
+    case NotAMethod                         => NotAMethod
+  }
+
 }
 
 object Signature {
+
   type ParamSig[T] = Either[Int, T]
 
   def apply[T](paramsSig: List[ParamSig[T]], resSig: T): MethodSignature[T] = new MethodSignature(paramsSig, resSig)
 
-  case object NotAMethod extends Signature[Nothing] {
-    def show: String = "<nosig>"
-  }
-  case class MethodSignature[T](paramsSig: List[ParamSig[T]], resSig: T) extends Signature[T] {
-    def show: String = s"""${paramsSig.map(_.merge).mkString("(", ", ", ")")}$resSig"""
-  }
+  case object NotAMethod extends Signature[Nothing]
+  case class MethodSignature[T] private[Signature] (paramsSig: List[ParamSig[T]], resSig: T) extends Signature[T]
 }

--- a/src/compiler/scala/tools/nsc/tasty/SignedName.scala
+++ b/src/compiler/scala/tools/nsc/tasty/SignedName.scala
@@ -1,5 +1,0 @@
-package scala.tools.nsc.tasty
-
-case class SignedName[TermName, TypeName](qual: TermName, sig: Signature[TypeName]) {
-  def show: String = s"[Signed $qual: ${sig.show}]"
-}

--- a/src/compiler/scala/tools/nsc/tasty/TastyNameTable.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TastyNameTable.scala
@@ -1,9 +1,0 @@
-package scala.tools.nsc.tasty
-
-import TastyRefs.NameRef
-
-trait TastyNameTable { self: TastyUniverse =>
-  val nameAtRef: NameRef => symbolTable.TermName
-  val signedNameAtRef: NameRef => Either[SigName, symbolTable.TermName]
-  val moduleRefs: NameRef => Boolean
-}

--- a/src/compiler/scala/tools/nsc/tasty/TastyUniverse.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TastyUniverse.scala
@@ -3,6 +3,8 @@ package scala.tools.nsc.tasty
 import scala.reflect.internal._
 import scala.reflect.io.AbstractFile
 import scala.annotation.tailrec
+import scala.tools.nsc.tasty.Names.TastyName
+import scala.tools.nsc.tasty.Names.TastyName.SimpleName
 
 trait TastyUniverse { self =>
   val symbolTable: SymbolTable
@@ -12,18 +14,12 @@ trait TastyUniverse { self =>
   import FlagSets._
   import Contexts._
 
+  final implicit val thisUniverse: self.type = self
   final implicit val symbolTablePrecise: self.symbolTable.type = self.symbolTable
 
   final def logTasty(str: => String): Unit = {
-    import symbolTable._
     if (settings.debugTasty) reporter.echo(NoPosition, str)
   }
-
-  type ParamSig = Signature.ParamSig[TypeName]
-  type Sig      = Signature[TypeName]
-  val  Sig      = Signature
-  type SigName  = SignedName[TermName, TypeName]
-  val  SigName  = SignedName
 
   object FlagSets {
     import scala.reflect.internal.{Flags, ModifierFlags}
@@ -463,4 +459,11 @@ trait TastyUniverse { self =>
         case Open        => "Open"
       }
     } mkString(" | ")
+
+  implicit class TastyNameDecorator(private val tastyName: TastyName) {
+    def toTermName: TermName = tastyName.export match {
+      case ""  => termNames.EMPTY
+      case raw => raw
+    }
+  }
 }


### PR DESCRIPTION
behaviour has not changed but it appears clear that names of the form `newTermName("scala.collection.immutable.List")` are necessary