### PR TITLE
Fail fast when select name from type is no symbol

### DIFF
--- a/src/compiler/scala/tools/nsc/tasty/ScalacUnpickler.scala
+++ b/src/compiler/scala/tools/nsc/tasty/ScalacUnpickler.scala
@@ -4,7 +4,6 @@ import TastyUnpickler.SectionUnpickler
 import TastyRefs.NameRef
 
 import scala.reflect.io.AbstractFile
-import scala.util.control.NonFatal
 
 object ScalacUnpickler {
 
@@ -30,20 +29,12 @@ object ScalacUnpickler {
     def unpickle(bytes: Array[Byte]/*, mode: UnpickleMode = UnpickleMode.TopLevel*/, classRoot: ClassSymbol, moduleRoot: ModuleSymbol, filename: String): Unit = {
       import Contexts._
       implicit val thisTasty: tasty.type = tasty
-      try {
-        logTasty(s"Unpickling $filename")
 
-        val unpickler: TastyUnpickler = new TastyUnpickler(bytes)
+      logTasty(s"Unpickling $filename")
 
-        val treeUnpickler = unpickler.unpickle[TreeUnpickler[tasty.type]](new TreeSectionUnpickler()(tasty)).get
-
-        implicit val ctx: Context = new InitialContext(classRoot, AbstractFile.getFile(filename))
-        treeUnpickler.enter(classRoot, moduleRoot)
-      } catch {
-        case NonFatal(ex) =>
-          ex.printStackTrace()
-          throw new RuntimeException(s"error reading TASTy from $filename: ${ex.getMessage()}")
-      }
+      val unpickler: TastyUnpickler = new TastyUnpickler(bytes)
+      val treeUnpickler = unpickler.unpickle[TreeUnpickler[tasty.type]](new TreeSectionUnpickler()(tasty)).get
+      treeUnpickler.enter(classRoot, moduleRoot)(new InitialContext(classRoot, AbstractFile.getFile(filename)))
     }
   }
 }

--- a/src/compiler/scala/tools/nsc/tasty/TastyModes.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TastyModes.scala
@@ -1,0 +1,18 @@
+package scala.tools.nsc.tasty
+
+/**Flags To Control traversal of Tasty
+ */
+object TastyModes {
+
+  final val EmptyTastyMode: TastyMode = TastyMode(0)
+  final val InParents: TastyMode      = TastyMode(1 << 0)
+
+  case class TastyMode(val toInt: Int) extends AnyVal {
+
+    def |(other: TastyMode): TastyMode = TastyMode(toInt | other.toInt)
+    def &(mask: TastyMode): TastyMode  = TastyMode(toInt & mask.toInt)
+    def is(mask: TastyMode): Boolean   = (this & mask) == mask
+
+  }
+
+}

--- a/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
@@ -6,6 +6,7 @@ import scala.collection.mutable
 import scala.reflect.io.AbstractFile
 import scala.tools.nsc.tasty.TastyUniverse
 import scala.tools.nsc.tasty.TastyName
+import scala.tools.nsc.tasty.TastyModes._
 
 trait ContextOps { self: TastyUniverse =>
   import FlagSets._
@@ -53,6 +54,7 @@ trait ContextOps { self: TastyUniverse =>
 
       def owner: Symbol
       def source: AbstractFile
+      def mode: TastyMode
 
       private[this] var _modules: mutable.AnyRefMap[TermName, ModuleSymbol] = null
       private[this] def modules = {
@@ -162,15 +164,17 @@ trait ContextOps { self: TastyUniverse =>
         withOwner(newLocalDummy)
 
       final def selectionCtx(name: TastyName): Context = this // if (name.isConstructorName) this.addMode(Mode.InSuperCall) else this
-      final def fresh(owner: Symbol): FreshContext = new FreshContext(owner, this)
-      final def fresh: FreshContext = new FreshContext(this.owner, this)
+      final def fresh(owner: Symbol): FreshContext = new FreshContext(owner, this, this.mode)
+      final def fresh: FreshContext = new FreshContext(this.owner, this, this.mode)
+      final def withMode(mode: TastyMode): FreshContext = new FreshContext(this.owner, this, this.mode | mode)
     }
 
     final class InitialContext(val topLevelClass: Symbol, val source: AbstractFile) extends Context {
+      def mode: TastyMode = EmptyTastyMode
       def owner: Symbol = topLevelClass.owner
     }
 
-    final class FreshContext(val owner: Symbol, val outer: Context) extends Context {
+    final class FreshContext(val owner: Symbol, val outer: Context, val mode: TastyMode) extends Context {
       def source: AbstractFile = outer.source
     }
   }

--- a/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
@@ -62,8 +62,8 @@ trait SymbolOps { self: TastyUniverse =>
     } else {
       val kind = if (name.isTermName) "term" else "type"
       val addendum =
-        if (ctx.mode.is(InParents)) s"parent $kind of ${if (ctx.owner.isLocalDummy) ctx.owner.owner else ctx.owner},"
-        else kind
+        if (ctx.mode.is(InParents)) s"$kind in parents of ${if (ctx.owner.isLocalDummy) ctx.owner.owner else ctx.owner}:"
+        else s"$kind in signature of ${ctx.owner}:"
       val msg =
         if (name.isTypeName && space.typeSymbol.isPackage)
           s"can't find $addendum ${space.typeSymbol.fullNameString}.$name; perhaps it is missing from the classpath."

--- a/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
@@ -63,9 +63,10 @@ trait SymbolOps { self: TastyUniverse =>
       val kind = if (name.isTermName) "term" else "type"
       val addendum =
         if (ctx.mode.is(InParents)) s"$kind in parents of ${if (ctx.owner.isLocalDummy) ctx.owner.owner else ctx.owner}:"
+        else if (ctx.owner.isClass) s"$kind required by a member of ${ctx.owner}:"
         else s"$kind in signature of ${ctx.owner}:"
       val msg =
-        if (name.isTypeName && space.typeSymbol.isPackage)
+        if (name.isTypeName && space.typeSymbol.hasPackageFlag)
           s"can't find $addendum ${space.typeSymbol.fullNameString}.$name; perhaps it is missing from the classpath."
         else
           s"can't find $addendum $name, in $space"

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
@@ -189,23 +189,17 @@ trait TypeOps { self: TastyUniverse =>
     tpe
   }
 
-  def reportThenErrorTpe(msg: String): Type = {
-    reporter.error(noPosition, msg)
-    errorType
-  }
+  def typeError[T](msg: String): T = throw new symbolTable.TypeError(msg)
 
-  def namedMemberOfPrefix(pre: Type, name: TastyName, selectingTerm: Boolean)(implicit ctx: Context): Type = {
+  def namedMemberOfPrefix(pre: Type, name: TastyName, selectingTerm: Boolean)(implicit ctx: Context): Type =
     namedMemberOfTypeWithPrefix(pre, pre, name, selectingTerm)
-  }
 
-  def namedMemberOfTypeWithPrefix(pre: Type, space: Type, tname: TastyName, selectingTerm: Boolean)(implicit ctx: Context): Type = {
-    namedMemberOfType(space, tname, selectingTerm).map(prefixedRef(pre, _)).fold(reportThenErrorTpe, identity)
-  }
+  def namedMemberOfTypeWithPrefix(pre: Type, space: Type, tname: TastyName, selectingTerm: Boolean)(implicit ctx: Context): Type =
+    prefixedRef(pre, namedMemberOfType(space, tname, selectingTerm))
 
   def constructorOfPrefix(pre: Type)(implicit ctx: Context): Type = {
-    def selectedCtor(ctor: Symbol): Type =
-      normaliseConstructorRef(ctor).tap(tpe => ctx.log(s"selected ${showSym(ctor)} : $tpe"))
-    constructorOfType(pre).fold(reportThenErrorTpe, selectedCtor)
+    val ctor = constructorOfType(pre)
+    normaliseConstructorRef(ctor).tap(tpe => ctx.log(s"selected ${showSym(ctor)} : $tpe"))
   }
 
   def lambdaResultType(resType: Type): Type = resType match {

--- a/src/tastytest/scala/tools/tastytest/Dotc.scala
+++ b/src/tastytest/scala/tools/tastytest/Dotc.scala
@@ -22,14 +22,14 @@ object Dotc {
     }
   }
 
-  def dotc(out: String, sources: String*): Try[Boolean] = {
+  def dotc(out: String, classpath: String, sources: String*): Try[Boolean] = {
     if (sources.isEmpty) {
       Success(true)
     }
     else {
       val args = Array(
         "-d", out,
-        "-classpath", out,
+        "-classpath", classpath,
         "-deprecation",
         "-Xfatal-warnings",
         "-usejavacp"
@@ -40,7 +40,7 @@ object Dotc {
 
   def main(args: Array[String]): Unit = {
     val Array(out, src) = args
-    val success = dotc(out, src).get
+    val success = dotc(out, out, src).get
     sys.exit(if (success) 0 else 1)
   }
 }

--- a/src/tastytest/scala/tools/tastytest/package.scala
+++ b/src/tastytest/scala/tools/tastytest/package.scala
@@ -6,11 +6,18 @@ import java.nio.file.FileSystems
 
 import scala.util.Try
 
-import Files.pathSep
+import Files.{pathSep, classpathSep}
 
   def printerrln(str: String): Unit = System.err.println(red(str))
   def printwarnln(str: String): Unit = System.err.println(yellow(str))
   def printsuccessln(str: String): Unit = System.err.println(green(str))
+
+  implicit final class ZipOps[T](val t: Try[T]) extends AnyVal {
+    @inline final def *>[U](u: Try[U]): Try[(T, U)] = for {
+      x <- t
+      y <- u
+    } yield (x, y)
+  }
 
   def cyan(str: String): String = Console.CYAN + str + Console.RESET
   def yellow(str: String): String = Console.YELLOW + str + Console.RESET
@@ -25,6 +32,7 @@ import Files.pathSep
   }
 
   private def path(part: String, parts: String*): String = (part +: parts).mkString(pathSep)
+  def classpath(path: String, paths: String*): String = (path +: paths).mkString(classpathSep)
 
   implicit final class OptionOps[A](val opt: Option[A]) extends AnyVal {
     @inline final def failOnEmpty(ifEmpty: => Throwable): Try[A] = opt.toRight(ifEmpty).toTry

--- a/test/tasty/neg-isolated/src-2/TestAnnotated.check
+++ b/test/tasty/neg-isolated/src-2/TestAnnotated.check
@@ -1,0 +1,4 @@
+TestAnnotated_fail.scala:5: error: can't find type required by a member of package tastytest: tastytest.annot; perhaps it is missing from the classpath.
+  def test = new Annotated {}
+                 ^
+1 error

--- a/test/tasty/neg-isolated/src-2/TestAnnotated_fail.scala
+++ b/test/tasty/neg-isolated/src-2/TestAnnotated_fail.scala
@@ -1,0 +1,7 @@
+package tastytest
+
+object TestAnnotated {
+
+  def test = new Annotated {}
+
+}

--- a/test/tasty/neg-isolated/src-2/TestChildren.check
+++ b/test/tasty/neg-isolated/src-2/TestChildren.check
@@ -1,7 +1,7 @@
-TestChildren_fail.scala:5: error: can't find parent type of class Child, tastytest.Parent; perhaps it is missing from the classpath.
+TestChildren_fail.scala:5: error: can't find type in parents of class Child: tastytest.Parent; perhaps it is missing from the classpath.
   def test1 = new Child
                   ^
-TestChildren_fail.scala:6: error: can't find parent type of object Module, tastytest.Parent; perhaps it is missing from the classpath.
+TestChildren_fail.scala:6: error: can't find type in parents of object Module: tastytest.Parent; perhaps it is missing from the classpath.
   def test2 = Module
       ^
 2 errors

--- a/test/tasty/neg-isolated/src-2/TestChildren.check
+++ b/test/tasty/neg-isolated/src-2/TestChildren.check
@@ -1,0 +1,7 @@
+TestChildren_fail.scala:5: error: can't find parent type of class Child, tastytest.Parent; perhaps it is missing from the classpath.
+  def test1 = new Child
+                  ^
+TestChildren_fail.scala:6: error: can't find parent type of object Module, tastytest.Parent; perhaps it is missing from the classpath.
+  def test2 = Module
+      ^
+2 errors

--- a/test/tasty/neg-isolated/src-2/TestChildren_fail.scala
+++ b/test/tasty/neg-isolated/src-2/TestChildren_fail.scala
@@ -1,0 +1,8 @@
+package tastytest
+
+object TestChildren {
+
+  def test1 = new Child
+  def test2 = Module
+
+}

--- a/test/tasty/neg-isolated/src-2/TestMethodDeps.check
+++ b/test/tasty/neg-isolated/src-2/TestMethodDeps.check
@@ -1,0 +1,4 @@
+TestMethodDeps_fail.scala:5: error: can't find type in signature of method parent: tastytest.Parent; perhaps it is missing from the classpath.
+  def test = MethodDeps.parent
+                        ^
+1 error

--- a/test/tasty/neg-isolated/src-2/TestMethodDeps_fail.scala
+++ b/test/tasty/neg-isolated/src-2/TestMethodDeps_fail.scala
@@ -1,0 +1,7 @@
+package tastytest
+
+object TestMethodDeps {
+
+  def test = MethodDeps.parent
+
+}

--- a/test/tasty/neg-isolated/src-3-A/Parent.scala
+++ b/test/tasty/neg-isolated/src-3-A/Parent.scala
@@ -1,0 +1,3 @@
+package tastytest
+
+class Parent

--- a/test/tasty/neg-isolated/src-3-A/annot.scala
+++ b/test/tasty/neg-isolated/src-3-A/annot.scala
@@ -1,0 +1,3 @@
+package tastytest
+
+final class annot extends scala.annotation.StaticAnnotation

--- a/test/tasty/neg-isolated/src-3-B/Annotated.scala
+++ b/test/tasty/neg-isolated/src-3-B/Annotated.scala
@@ -1,0 +1,4 @@
+package tastytest
+
+@annot
+trait Annotated

--- a/test/tasty/neg-isolated/src-3-B/Children.scala
+++ b/test/tasty/neg-isolated/src-3-B/Children.scala
@@ -1,0 +1,4 @@
+package tastytest
+
+class Child extends Parent
+object Module extends Parent

--- a/test/tasty/neg-isolated/src-3-B/MethodDeps.scala
+++ b/test/tasty/neg-isolated/src-3-B/MethodDeps.scala
@@ -1,0 +1,5 @@
+package tastytest
+
+object MethodDeps {
+  def parent: Parent = Module
+}

--- a/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
+++ b/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
@@ -39,6 +39,14 @@ class TastyTestJUnit {
     additionalSettings = Nil
   ).get
 
+  @test def negIsolated(): Unit = TastyTest.negSuiteIsolated(
+    src                = "neg-isolated",
+    srcRoot            = assertPropIsSet(propSrc),
+    pkgName            = assertPropIsSet(propPkgName),
+    outDirs            = None,
+    additionalSettings = Nil
+  ).get
+
   val propSrc          = "tastytest.src"
   val propPkgName      = "tastytest.packageName"
 


### PR DESCRIPTION
fixes #10 

* Adds `TastyMode`, to track when unpickling parent types.
* Adds a new `neg-isolated` test mode to TastyTest, which compiles some dotty code to classpath A, compiles other dotty code to classpath B (with access to classpath A), and then scala 2 only has access to classpath B, so some dotty dependencies are missing.