### PR TITLE
refactor tasty name, add ErasedTypeRef, special case repeated class

### DIFF
--- a/src/compiler/scala/tools/nsc/tasty/ErasedTypeRef.scala
+++ b/src/compiler/scala/tools/nsc/tasty/ErasedTypeRef.scala
@@ -1,0 +1,42 @@
+package scala.tools.nsc.tasty
+
+import scala.tools.nsc.tasty.TastyName.{ModuleName, QualifiedName, SimpleName}
+
+case class ErasedTypeRef(arrayDims: Int, qualifiedName: String, isModule: Boolean) {
+  def signature: String = {
+    s"${"[" * arrayDims}${if (isModule) s"object $qualifiedName" else qualifiedName}"
+  }
+}
+
+object ErasedTypeRef {
+
+  def apply(tname: TastyName): Option[ErasedTypeRef] = {
+
+    def name(pkg: String, terminal: String) = if (pkg.isEmpty) terminal else s"$pkg.$terminal"
+
+    def specialised(arrayDims: Int, pkg: String, terminal: String, isModule: Boolean): ErasedTypeRef = terminal match {
+      case s"$inner[]" => specialised(arrayDims + 1, pkg, inner, isModule)
+      case clazz       => ErasedTypeRef(arrayDims, name(pkg, clazz), isModule)
+    }
+
+    var isModule = false
+
+    val classKind = tname match {
+      case ModuleName(classKind) =>
+        isModule = true
+        classKind
+      case nonModule => nonModule
+    }
+
+    classKind match {
+      case terminal: SimpleName => // unqualified in the <empty> package
+        Some(specialised(0, "", terminal.raw, isModule))
+      case QualifiedName(path, TastyName.PathSep, terminal) =>
+        Some(specialised(0, path.source, terminal.raw, isModule))
+      case _ =>
+        None
+    }
+
+  }
+
+}

--- a/src/compiler/scala/tools/nsc/tasty/bridge/NameOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/NameOps.scala
@@ -8,18 +8,25 @@ trait NameOps { self: TastyUniverse =>
 
   def isConstructorName(name: Name) = symbolTable.nme.isConstructorName(name)
 
-  def encodeAsTermName(tastyName: TastyName): TermName = tastyName match {
-    case Empty                                    => termNames.EMPTY
-    case Constructor | SignedName(Constructor, _) => nme.CONSTRUCTOR
-    case EmptyPkg                                 => nme.EMPTY_PACKAGE_NAME
-    case RootClass                                => nme.ROOT
-    case WildcardName()                           => nme.WILDCARD
-    case name                                     => mkTermName(name.encoded)
+  private def encodeAsTermName(tastyName: TastyName): TermName = tastyName match {
+    case Empty          => termNames.EMPTY
+    case Constructor    => nme.CONSTRUCTOR
+    case EmptyPkg       => nme.EMPTY_PACKAGE_NAME
+    case RootClass      => nme.ROOT
+    case WildcardName() => nme.WILDCARD
+    case name           => mkTermName(name.encoded)
   }
 
-  def encodeTastyName(tastyName: TastyName, isTerm: Boolean): Name = {
-    val encoded = encodeAsTermName(tastyName)
-    if (isTerm) encoded else encoded.toTypeName
+  private def encodeAsTypeName(tastyName: TastyName): TypeName = tastyName match {
+    case RepeatedClass => tpnme.REPEATED_PARAM_CLASS_NAME
+    case name          => encodeAsTermName(name).toTypeName
   }
+
+  def encodeTastyNameAsTerm(tastyName: TastyName): TermName = encodeAsTermName(tastyName.stripSignedPart)
+  def encodeTastyNameAsType(tastyName: TastyName): TypeName = encodeAsTypeName(tastyName.stripSignedPart)
+
+  def encodeTastyName(tastyName: TastyName, isTerm: Boolean): Name =
+    if (isTerm) encodeTastyNameAsTerm(tastyName)
+    else encodeTastyNameAsType(tastyName)
 
 }

--- a/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
@@ -45,7 +45,7 @@ trait SymbolOps { self: TastyUniverse =>
     val selector = encodeTastyName(tname, selectingTerm)
     tname.signature match {
       case NotAMethod => memberOfSpace(space, selector, tname.isModuleName)
-      case sig        => signedMemberOfSpace(space, selector, sig.map(erasedNameToErasedType))
+      case sig        => signedMemberOfSpace(space, selector, sig.map(resolveErasedTypeRef))
     }
   }
 

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TastyKernel.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TastyKernel.scala
@@ -110,7 +110,7 @@ trait TastyKernel { self: TastyUniverse =>
     final def scalaRepeatedType(arg: Type): Type = symbolTable.definitions.scalaRepeatedType(arg)
     final def repeatedAnnotationClass(implicit ctx: Contexts.Context): Option[Symbol] = ctx.loadingMirror.getClassIfDefined("scala.annotation.internal.Repeated").toOption
     final def childAnnotationClass(implicit ctx: Contexts.Context): Option[Symbol] = ctx.loadingMirror.getClassIfDefined("scala.annotation.internal.Child").toOption
-    final def arrayType(arg: Type): Type = symbolTable.definitions.arrayType(arg)
+    final def arrayType(dims: Int, arg: Type): Type = (0 until dims).foldLeft(arg)((acc, _) => symbolTable.definitions.arrayType(acc))
   }
 
   object nme {
@@ -124,6 +124,10 @@ trait TastyKernel { self: TastyUniverse =>
     final val EMPTY_PACKAGE_NAME: TermName = symbolTable.nme.EMPTY_PACKAGE_NAME
     final val WILDCARD: TermName = symbolTable.nme.WILDCARD
     final def freshWhileName: TermName = symbolTable.freshTermName(symbolTable.nme.WHILE_PREFIX)(symbolTable.currentFreshNameCreator)
+  }
+
+  object tpnme {
+    final val REPEATED_PARAM_CLASS_NAME: TypeName = symbolTable.tpnme.REPEATED_PARAM_CLASS_NAME
   }
 
   object untpd {

--- a/test/tasty/run/pre/tastytest/package.scala
+++ b/test/tasty/run/pre/tastytest/package.scala
@@ -16,7 +16,7 @@ package object tastytest {
         c.Expr[Boolean](q"true")
       }
       else {
-        c.error(NoPosition, s"${weakTypeOf[T]} does not have a member with annotation ${weakTypeOf[A]}")
+        c.error(c.enclosingPosition, s"${weakTypeOf[T]} does not have a member with annotation ${weakTypeOf[A]}")
         c.Expr[Boolean](q"false")
       }
     }

--- a/test/tasty/run/src-2/tastytest/TestArrayCtors.scala
+++ b/test/tasty/run/src-2/tastytest/TestArrayCtors.scala
@@ -1,7 +1,10 @@
 package tastytest
 
+import ArrayCtors._
+
 object TestArrayCtors extends Suite("TestArrayCtors") {
 
-  test(assert(ArrayCtors.EmptyArrayCtor.arr.length == 0))
+  test(assert(EmptyArrayCtor != null))
+  test(assert(EmptyArrayCtor2 != null))
 
 }

--- a/test/tasty/run/src-3/tastytest/ArrayCtors.scala
+++ b/test/tasty/run/src-3/tastytest/ArrayCtors.scala
@@ -2,10 +2,15 @@ package tastytest
 
 object ArrayCtors {
 
+  final class arrayAnnot(val arr: Array[Module.type]) extends scala.annotation.StaticAnnotation
+  final class arrayAnnot2(val arr: Array[Array[Module.type]]) extends scala.annotation.StaticAnnotation
+
   object Module
 
-  class ArrayCtor(val arr: Array[Module.type])
+  @arrayAnnot(Array[Module.type]())
+  object EmptyArrayCtor
 
-  object EmptyArrayCtor extends ArrayCtor(Array[Module.type]())
+  @arrayAnnot2(Array[Array[Module.type]]())
+  object EmptyArrayCtor2
 
 }


### PR DESCRIPTION
fixes #73 

Adds `ErasedTypeRef`, which is a data structure making it more efficient to resolve a `SignedName` to the erasure of a method, and fails fast if the assumptions about its structure are incorrect.

Also changes the `ArrayCtors` test to use an annotation with an argument of a multidimensional array of a module class to force reading of complex signatures.