### PR TITLE
Rework error handling and logging

### DIFF
--- a/src/compiler/scala/tools/nsc/tasty/TastyUniverse.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TastyUniverse.scala
@@ -3,7 +3,6 @@ package scala.tools.nsc.tasty
 import bridge._
 
 abstract class TastyUniverse extends TastyKernel
-  with LoggingOps
   with FlagOps
   with TypeOps
   with AnnotationOps

--- a/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
@@ -862,7 +862,7 @@ class TreeUnpickler[Tasty <: TastyUniverse](
               //               refine self type of the owner to be aware of the alias.
               sym.info = rhs.tpe match {
                 case bounds @ TypeBounds(lo: PolyType, hi: PolyType) if !(mergeableParams(lo,hi)) =>
-                  typeError(s"$sym has diverging type lambdas as bounds:$bounds")
+                  ctx.unsupportedError(s"diverging higher kinded bounds: $sym$bounds")
                 case tpe: TypeBounds => normaliseBounds(tpe)
                 case tpe             => tpe
               }

--- a/src/compiler/scala/tools/nsc/tasty/bridge/AnnotationOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/AnnotationOps.scala
@@ -3,15 +3,16 @@ package scala.tools.nsc.tasty.bridge
 import scala.tools.nsc.tasty.{SafeEq, TastyUniverse}
 
 trait AnnotationOps { self: TastyUniverse =>
+  import self.{symbolTable => u}
 
   object Annotation {
-    def deferredSymAndTree(annotee: Symbol)(symf: => Symbol)(tree: => Option[Tree])(implicit ctx: Contexts.Context): Annotation =
+    def deferredSymAndTree(annotee: Symbol)(symf: => Symbol)(tree: => Tree)(implicit ctx: Contexts.Context): Annotation =
       new symbolTable.LazyAnnotationInfo({
         val annotSym = symf
-        val annotTree = tree.getOrElse(emptyTree)
+        val annotTree = tree
         val isChild = defn.childAnnotationClass.exists(annotSym === _)
         ctx.log(s"annotation of $annotee = $annotTree")
-        if (isChild) symbolTable.AnnotationInfo(annotTree.tpe, Nil, Nil)
+        if (isChild) u.AnnotationInfo(annotTree.tpe, Nil, Nil)
         else mkAnnotation(annotTree)
       })
   }

--- a/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
@@ -5,9 +5,10 @@ import TastyFlags._
 import scala.tools.nsc.tasty.TastyUniverse
 
 trait FlagOps { self: TastyUniverse =>
+  import self.{symbolTable => u}
 
   object FlagSets {
-    import symbolTable.Flag
+    import u.Flag
     import scala.reflect.internal.{Flags, ModifierFlags}
 
     val Package: FlagSet = Flags.PACKAGE
@@ -53,7 +54,7 @@ trait FlagOps { self: TastyUniverse =>
 
     implicit class FlagSetOps(private val flagSet: FlagSet) {
       private def flags: FlagSet = {
-        val fs = flagSet & phase.flagMask
+        val fs = flagSet & u.phase.flagMask
         (fs | ((fs & Flags.LateFlags) >>> Flags.LateShift)) & ~((fs & Flags.AntiFlags) >>> Flags.AntiShift)
       }
       private def getFlag(mask: FlagSet): FlagSet = {
@@ -67,7 +68,7 @@ trait FlagOps { self: TastyUniverse =>
     }
   }
 
-  def show(flags: FlagSet): String = symbolTable.show(flags)
+  def show(flags: FlagSet): String = u.show(flags)
 
   def show(flags: TastyFlagSet): String =
     if (!flags) "EmptyTastyFlags"

--- a/src/compiler/scala/tools/nsc/tasty/bridge/LoggingOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/LoggingOps.scala
@@ -1,9 +1,0 @@
-package scala.tools.nsc.tasty.bridge
-
-import scala.tools.nsc.tasty.TastyUniverse
-
-trait LoggingOps { self: TastyUniverse =>
-  @inline final def logTasty(str: => String): Unit = {
-    if (settings.YdebugTasty) reporter.echo(noPosition, str)
-  }
-}

--- a/src/compiler/scala/tools/nsc/tasty/bridge/NameOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/NameOps.scala
@@ -4,9 +4,10 @@ import scala.tools.nsc.tasty.TastyName
 import scala.tools.nsc.tasty.TastyUniverse
 
 trait NameOps { self: TastyUniverse =>
+  import self.{symbolTable => u}
   import TastyName._
 
-  def isConstructorName(name: Name) = symbolTable.nme.isConstructorName(name)
+  def isConstructorName(name: Name) = u.nme.isConstructorName(name)
 
   private def encodeAsTermName(tastyName: TastyName): TermName = tastyName match {
     case Empty          => termNames.EMPTY

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
@@ -10,6 +10,7 @@ import scala.util.chaining._
 import scala.collection.mutable
 
 trait TypeOps { self: TastyUniverse =>
+  import self.{symbolTable => u}
   import Contexts._
   import SymbolOps._
   import FlagSets._
@@ -18,19 +19,11 @@ trait TypeOps { self: TastyUniverse =>
   def mergeableParams(t: Type, u: Type): Boolean =
     t.typeParams.size == u.typeParams.size
 
-  def attachCompiletimeOnly(owner: Symbol, msg: String): Unit = {
-    owner.addAnnotation(defn.CompileTimeOnlyAttr, Literal(Constant(msg)))
-  }
+  def attachTypeError[T](msg: Symbol => String)(implicit ctx: Context): T =
+    findOwner(owner => typeError(msg(owner)))
 
-  def attachCompiletimeOnly(msg: Symbol => String)(implicit ctx: Context): Unit = {
-    findOwner(owner => attachCompiletimeOnly(owner, msg(owner)))
-  }
-
-  def findOwner[U](op: Symbol => U)(implicit ctx: Context): Unit = {
-    for (owner <- ctx.owner.ownerChain.find(sym => !sym.is(Param))) {
-      op(owner)
-    }
-  }
+  def findOwner[T](op: Symbol => T)(implicit ctx: Context): T =
+    ctx.owner.ownerChain.find(sym => !sym.is(Param)).fold(op(noSymbol))(op)
 
   def normaliseBounds(bounds: TypeBounds): Type = {
     val TypeBounds(lo, hi) = bounds
@@ -61,11 +54,10 @@ trait TypeOps { self: TastyUniverse =>
 
     def typeRefUncurried(tycon: Type, args: List[Type]): Type = tycon match {
       case tycon: TypeRef if tycon.typeArgs.nonEmpty =>
-        attachCompiletimeOnly(owner =>
+        attachTypeError(owner =>
           s"Unsupported Scala 3 curried type application $tycon[${args.mkString(",")}] in signature of $owner")
-        errorType
       case _ =>
-        mkAppliedType(tycon, args)
+        u.appliedType(tycon, args)
     }
 
     if (args.exists(tpe => tpe.isInstanceOf[TypeBounds] | tpe.isInstanceOf[LambdaPolyType])) {
@@ -77,7 +69,7 @@ trait TypeOps { self: TastyUniverse =>
       }
       val args1 = args.map(bindWildcards)
       if (syms.isEmpty) typeRefUncurried(tycon, args1)
-      else mkExistentialType(syms.toList, typeRefUncurried(tycon, args1))
+      else u.internal.existentialType(syms.toList, typeRefUncurried(tycon, args1))
     }
     else {
       typeRefUncurried(tycon, args)
@@ -101,13 +93,8 @@ trait TypeOps { self: TastyUniverse =>
 
   def selectType(pre: Type, space: Type, name: TastyName)(implicit ctx: Context): Type = {
     if (pre.typeSymbol === defn.ScalaPackage && ( name === nme.And || name === nme.Or ) ) {
-      if (name === nme.And) {
-        AndType
-      }
-      else {
-        attachCompiletimeOnly(owner => s"Scala 3 union types are not supported for $owner")
-        errorType
-      }
+      if (name === nme.And) AndType
+      else attachTypeError(owner => s"Scala 3 union types are not supported for $owner")
     }
     else {
       namedMemberOfTypeWithPrefix(pre, space, name, selectingTerm = false)
@@ -120,7 +107,7 @@ trait TypeOps { self: TastyUniverse =>
   /**
    * Ported from dotc
    */
-  abstract class TastyLazyType extends LazyType with FlagAgnosticCompleter { self =>
+  abstract class TastyLazyType extends u.LazyType with u.FlagAgnosticCompleter { self =>
     private[this] val NoSymbolFn = (_: Context) => noSymbol
     private[this] var myDecls: Scope = emptyScope
     private[this] var mySourceModuleFn: Context => Symbol = NoSymbolFn
@@ -167,8 +154,6 @@ trait TypeOps { self: TastyUniverse =>
     if (tParams.nonEmpty) tpe = mkPolyType(tParams, tpe)
     tpe
   }
-
-  def typeError[T](msg: String): T = throw new symbolTable.TypeError(msg)
 
   def namedMemberOfPrefix(pre: Type, name: TastyName, selectingTerm: Boolean)(implicit ctx: Context): Type =
     namedMemberOfTypeWithPrefix(pre, pre, name, selectingTerm)
@@ -217,7 +202,29 @@ trait TypeOps { self: TastyUniverse =>
     }
   }
 
-  def typeRef(tpe: Type): Type = mkAppliedType(tpe, Nil)
+  def typeRef(tpe: Type): Type = u.appliedType(tpe, Nil)
+
+  /** The given type, unless `sym` is a constructor, in which case the
+   *  type of the constructed instance is returned
+   */
+  def effectiveResultType(sym: Symbol, typeParams: List[Symbol], givenTp: Type): Type =
+    if (sym.name == nme.CONSTRUCTOR) sym.owner.tpe
+    else givenTp
+
+  /** The method type corresponding to given parameters and result type */
+  def mkDefDefType(typeParams: List[Symbol], valueParamss: List[List[Symbol]], resultType: Type): Type = {
+    val monotpe = valueParamss.foldRight(resultType)((ts, f) => u.internal.methodType(ts, f))
+    val exprMonotpe = {
+      if (valueParamss.nonEmpty)
+        monotpe
+      else
+        mkNullaryMethodType(monotpe)
+    }
+    if (typeParams.nonEmpty)
+      mkPolyType(typeParams, exprMonotpe)
+    else
+      exprMonotpe
+  }
 
   def mkLambdaPolyType(typeParams: List[Symbol], resTpe: Type): LambdaPolyType = new LambdaPolyType(typeParams, resTpe)
   def mkLambdaFromParams(typeParams: List[Symbol], ret: Type): PolyType = mkPolyType(typeParams, lambdaResultType(ret))
@@ -345,7 +352,7 @@ trait TypeOps { self: TastyUniverse =>
 
     validateThisLambda()
 
-    def canonical: MethodType = mkMethodType(params, resType)
+    def canonical: MethodType = u.internal.methodType(params, resType)
 
     override def canEqual(that: Any): Boolean = that.isInstanceOf[MethodTermLambda]
   }
@@ -402,5 +409,4 @@ trait TypeOps { self: TastyUniverse =>
     override def canEqual(that: Any): Boolean = that.isInstanceOf[PolyTypeLambda]
   }
 
-  def showRaw(tpe: Type): String = symbolTable.showRaw(tpe)
 }

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
@@ -104,24 +104,22 @@ trait TypeOps { self: TastyUniverse =>
   def selectTerm(pre: Type, space: Type, name: TastyName)(implicit ctx: Context): Type =
     namedMemberOfTypeWithPrefix(pre, space, name, selectingTerm = true)
 
+  private[this] val NoSymbolFn = (_: Context) => noSymbol
+
   /**
    * Ported from dotc
    */
-  abstract class TastyLazyType extends u.LazyType with u.FlagAgnosticCompleter { self =>
-    private[this] val NoSymbolFn = (_: Context) => noSymbol
+  abstract class TastyLazyType extends u.LazyType with u.FlagAgnosticCompleter {
     private[this] var myDecls: Scope = emptyScope
     private[this] var mySourceModuleFn: Context => Symbol = NoSymbolFn
-    private[this] var myModuleClassFn: Context => Symbol = NoSymbolFn
     private[this] var myTastyFlagSet: TastyFlagSet = emptyTastyFlags
 
     override def decls: Scope = myDecls
     def sourceModule(implicit ctx: Context): Symbol = mySourceModuleFn(ctx)
-    def moduleClass(implicit ctx: Context): Symbol = myModuleClassFn(ctx)
     def tastyFlagSet: TastyFlagSet = myTastyFlagSet
 
     def withDecls(decls: Scope): this.type = { myDecls = decls; this }
     def withSourceModule(sourceModuleFn: Context => Symbol): this.type = { mySourceModuleFn = sourceModuleFn; this }
-    def withModuleClass(moduleClassFn: Context => Symbol): this.type = { myModuleClassFn = moduleClassFn; this }
     def withTastyFlagSet(flags: TastyFlagSet): this.type = { myTastyFlagSet = flags; this }
 
     override def load(sym: Symbol): Unit = complete(sym)

--- a/test/tasty/neg/src-2/TestHKNest.check
+++ b/test/tasty/neg/src-2/TestHKNest.check
@@ -1,4 +1,4 @@
-TestHKNest_fail.scala:6: error: type F has diverging type lambdas as bounds: >: [X]tastytest.HKNest.Arg1[X] <: [Y, Z]tastytest.HKNest.QuxArg[Y]
+TestHKNest_fail.scala:6: error: Unsupported Scala 3 diverging higher kinded bounds: type F >: [X]tastytest.HKNest.Arg1[X] <: [Y, Z]tastytest.HKNest.QuxArg[Y]; found in method foo in class HKClass_14.
   def test14 = new HKClass_14[Quuux].foo(new Quuux[QuxArg]) // error: diverging lamdba type bounds
                                      ^
 1 error

--- a/test/tasty/neg/src-2/TestHKNest.check
+++ b/test/tasty/neg/src-2/TestHKNest.check
@@ -1,7 +1,4 @@
 TestHKNest_fail.scala:6: error: type F has diverging type lambdas as bounds: >: [X]tastytest.HKNest.Arg1[X] <: [Y, Z]tastytest.HKNest.QuxArg[Y]
   def test14 = new HKClass_14[Quuux].foo(new Quuux[QuxArg]) // error: diverging lamdba type bounds
                                      ^
-TestHKNest_fail.scala:7: error: type F has diverging type lambdas as bounds: >: [X]tastytest.HKNest.Arg1[X] <: [Y, Z]tastytest.HKNest.QuxArg[Y]
-  def test15 = new HKClass_14[Quuuux].foo(new Quuuux[DummyQuxArg]) // error: diverging lamdba type bounds
-                                      ^
-2 errors
+1 error

--- a/test/tasty/neg/src-2/TestHKNest2.check
+++ b/test/tasty/neg/src-2/TestHKNest2.check
@@ -1,4 +1,4 @@
-TestHKNest2_fail.scala:6: error: Scala 3 union types are not supported for method foo
+TestHKNest2_fail.scala:6: error: Unsupported Scala 3 union type; found in method foo in class HKClass_15.
   def test16 = new HKClass_15().foo(List(1,2,3)) // error: Union type not supported
                                 ^
 1 error

--- a/test/tasty/neg/src-2/TestHKNest2.check
+++ b/test/tasty/neg/src-2/TestHKNest2.check
@@ -1,7 +1,4 @@
 TestHKNest2_fail.scala:6: error: Scala 3 union types are not supported for method foo
   def test16 = new HKClass_15().foo(List(1,2,3)) // error: Union type not supported
                                 ^
-TestHKNest2_fail.scala:7: error: Scala 3 union types are not supported for method foo
-  def test17 = new HKClass_15().foo(Option(1))   // error: Union type not supported
-                                ^
-2 errors
+1 error

--- a/test/tasty/neg/src-2/TestHKNest3.check
+++ b/test/tasty/neg/src-2/TestHKNest3.check
@@ -1,7 +1,7 @@
-TestHKNest3_fail.scala:6: error: Unsupported Scala 3 curried type application F[T][U] in signature of method foo
+TestHKNest3_fail.scala:6: error: Unsupported Scala 3 curried type application F[T][U]; found in method foo in class HKClass_13.
   def test13 = new HKClass_13[HKLam].foo[Int,String](("",0)) // error: unsupported curried type application
                                      ^
-TestHKNest3_fail.scala:7: error: Unsupported Scala 3 curried type application F[T][U] in signature of method foo
+TestHKNest3_fail.scala:7: error: Unsupported Scala 3 curried type application F[T][U]; found in method foo in class HKClass_16.
   def test16 = new HKClass_16[List].foo[HKLam,Int,String](("",0) :: Nil)
                                     ^
 2 errors

--- a/test/tasty/neg/src-2/TestHello.check
+++ b/test/tasty/neg/src-2/TestHello.check
@@ -1,9 +1,6 @@
-error: Scala 2 incompatible TASTy signature of HelloWorld.tasty in object HelloWorld: inline val msg with non-constant type String
-TestHello_fail.scala:5: error: type mismatch;
- found   : helloworld.TestHello.helloworld.type (with underlying type String)
- required: helloworld.HelloWorld.msg1.type
-  HelloWorld.acceptsOnlyMsg1(helloworld)
-                             ^
+TestHello_fail.scala:4: error: Unsupported Scala 3 inline val msg with non-constant type String; found in object HelloWorld in package helloworld.
+  val helloworld = HelloWorld.msg
+                              ^
 TestHello_fail.scala:6: error: inferred type arguments [List[String]] do not conform to method higherBounded2's type parameter bounds [T <: List[_ <: Int]]
   HelloWorld.higherBounded2(List(""))
              ^
@@ -38,4 +35,4 @@ List's type parameters do not match type F's expected parameters:
 type A is covariant, but type _ is declared contravariant
   HelloWorld.higherBounded6[List]
                            ^
-10 errors
+9 errors

--- a/test/tasty/neg/src-2/TestIntent.check
+++ b/test/tasty/neg/src-2/TestIntent.check
@@ -1,10 +1,7 @@
-TestIntent_fail.scala:7: error: Unsupported Scala 3 inline method here
-    in("should be 6")(toEqual(expect(3 + 3))(6))
-                                    ^
-TestIntent_fail.scala:7: error: Unsupported Scala 3 inline method here
-    in("should be 6")(toEqual(expect(3 + 3))(6))
-                     ^
-TestIntent_fail.scala:6: error: Unsupported Scala 3 inline method here
+TestIntent_fail.scala:6: error: Unsupported Scala 3 inline method here; found in object Position in package intent.
   apply("3 + 3") {
                  ^
-3 errors
+TestIntent_fail.scala:7: error: could not find implicit value for parameter pos: tastytest.intent.Position
+    in("should be 6")(toEqual(expect(3 + 3))(6))
+                     ^
+2 errors


### PR DESCRIPTION
Single method of error handling:
* throw a `TypeError` which is caught in `readNewMember`, this sets the info to `ErrorType`, and is then rethrown. By throwing `TypeError` the error is reported alongside the source code calling the bad signature.
* There is a helper method which provides standard formatting for an error, linking the origin to a publicly visible definition that the user can look up.

There is now a single log method, that depends on `Context`

Also `Context` no longer caches module symbols