### PR TITLE
Read inner classes in signatures, force annotations after template parents

### DIFF
--- a/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
@@ -74,6 +74,30 @@ trait ContextOps { self: TastyUniverse =>
     else u.NoSymbol //throw new AssertionError(s"no module $name in ${location(owner)}")
   }
 
+  /**Perform an operation within a context that has the mode [[IndexStats]] will force any collected annotations
+   * afterwards*/
+  def inIndexingContext(op: Context => Unit)(implicit ctx: Context): Unit = {
+    val statsCtx = ctx.addMode(IndexStats)
+    op(statsCtx)
+    statsCtx.initialContext.forceAnnotations()
+  }
+
+
+
+  /**Forces lazy annotations, if one is [[scala.annotation.internal.Child]] then it will add the referenced type as a
+   * sealed child.
+   */
+  private def analyseAnnotations(sym: Symbol)(implicit ctx: Context): Unit = {
+    for (annot <- sym.annotations) {
+      annot.completeInfo()
+      if (annot.tpe.typeSymbolDirect === defn.ChildAnnot) {
+        val child = annot.tpe.typeArgs.head.typeSymbolDirect
+        sym.addChild(child)
+        ctx.log(s"adding sealed child ${showSym(child)} to ${showSym(sym)}")
+      }
+    }
+  }
+
   /**Maintains state through traversal of a TASTy file, such as the outer scope of the defintion being traversed, the
    * traversal mode, and the root owners and source path for the TASTy file.
    * It also provides all operations for manipulation of the symbol table, such as creating/updating symbols and
@@ -82,56 +106,14 @@ trait ContextOps { self: TastyUniverse =>
   sealed abstract class Context {
     thisCtx =>
 
-    private[this] implicit final def implyThisCtx: thisCtx.type = thisCtx
-
-    private[this] var mySymbolsToForceAnnots: mutable.LinkedHashSet[Symbol] = _
-
-    private def stageSymbolToForceAnnots(sym: Symbol): Unit = {
-      if (sym.annotations.nonEmpty) {
-        if (mySymbolsToForceAnnots == null) {
-          mySymbolsToForceAnnots = mutable.LinkedHashSet.empty
-        }
-        mySymbolsToForceAnnots += sym
-      }
-    }
-
-    /** Force any lazy annotations collected from declaration statements directly in this scope.
-     *
-     *  It is important to call this *after* indexing statements in a scope, otherwise calling
-     *  [[ownertree.findOwner]] can fail, this is because [[ownertree.findOwner]] cannot traverse a definition tree at
-     *  a given address before a symbol has been registered to that address.
-     */
-    def forceAnnotations(): Unit = {
-      if (mySymbolsToForceAnnots != null) {
-        val toForce = mySymbolsToForceAnnots
-        mySymbolsToForceAnnots = null
-        for (sym <- toForce) {
-          log(s"!!! forcing annotations on ${showSym(sym)}")
-          analyseAnnotations(sym)
-        }
-      }
-    }
-
-    /**Forces lazy annotations, if one is [[scala.annotation.internal.Child]] then it will add the referenced type as a
-     * sealed child.
-     */
-    private def analyseAnnotations(sym: Symbol): Unit = {
-      for (annot <- sym.annotations) {
-        annot.completeInfo()
-        if (annot.tpe.typeSymbolDirect === defn.ChildAnnot) {
-          val child = annot.tpe.typeArgs.head.typeSymbolDirect
-          sym.addChild(child)
-          log(s"adding sealed child ${showSym(child)} to ${showSym(sym)}")
-        }
-      }
-    }
+    protected implicit final def implyThisCtx: thisCtx.type = thisCtx
 
     /**Associates the annotations with the symbol, and will force their evaluation if not reading statements.*/
     def adjustAnnotations(sym: Symbol, annots: List[DeferredAnnotation]): Unit = {
       if (annots.nonEmpty) {
         if (mode.is(IndexStats)) {
           log(s"lazily adding annotations to ${showSym(sym)}")
-          stageSymbolToForceAnnots(sym.setAnnotations(annots.map(_.lzy(sym))))
+          initialContext.stageSymbolToForceAnnots(sym.setAnnotations(annots.map(_.lzy(sym))))
         }
         else {
           log(s"eagerly adding annotations to ${showSym(sym)}")
@@ -428,36 +410,30 @@ trait ContextOps { self: TastyUniverse =>
     }
 
     final def withOwner(owner: Symbol): Context =
-      if (owner `ne` this.owner) fresh(owner) else this
+      if (owner `ne` this.owner) freshSymbol(owner) else this
 
     final def withNewScope: Context =
-      fresh(newLocalDummy)
+      freshSymbol(newLocalDummy)
 
     final def selectionCtx(name: TastyName): Context = this // if (name.isConstructorName) this.addMode(Mode.InSuperCall) else this
-    final def fresh(owner: Symbol): FreshContext = new FreshContext(owner, this, this.mode)
-
-    private def sibling(mode: TastyMode): FreshContext = new FreshContext(this.owner, outerOrThis, mode)
-    private def sibling: FreshContext = sibling(mode)
-
-    private def outerOrThis: Context = this match {
-      case ctx: FreshContext => ctx.outer
-      case ctx               => ctx
-    }
+    final def freshSymbol(owner: Symbol): FreshContext = new FreshContext(owner, this, this.mode)
+    final def freshMode(mode: TastyMode): FreshContext = new FreshContext(this.owner, this, mode)
+    final def fresh: FreshContext                      = new FreshContext(this.owner, this, this.mode)
 
     final def addMode(mode: TastyMode): Context =
-      if (!this.mode.is(mode)) sibling(this.mode | mode)
+      if (!this.mode.is(mode)) freshMode(this.mode | mode)
       else this
 
     final def retractMode(mode: TastyMode): Context =
-      if (this.mode.isOneOf(mode)) sibling(this.mode &~ mode)
+      if (this.mode.isOneOf(mode)) freshMode(this.mode &~ mode)
       else this
 
     final def withMode(mode: TastyMode): Context =
-      if (mode != this.mode) sibling(mode)
+      if (mode != this.mode) freshMode(mode)
       else this
 
     final def withSource(source: AbstractFile): Context =
-      if (source `ne` this.source) sibling.atSource(source)
+      if (source `ne` this.source) fresh.atSource(source)
       else this
 
     final def withPhaseNoLater[T](phase: String)(op: Context => T): T =
@@ -468,6 +444,36 @@ trait ContextOps { self: TastyUniverse =>
   final class InitialContext(val topLevelClass: Symbol, val source: AbstractFile) extends Context {
     def mode: TastyMode = EmptyTastyMode
     def owner: Symbol = topLevelClass.owner
+
+    private[this] var mySymbolsToForceAnnots: mutable.LinkedHashSet[Symbol] = _
+
+    private[ContextOps] def stageSymbolToForceAnnots(sym: Symbol): Unit = {
+      if (sym.annotations.nonEmpty) {
+        if (mySymbolsToForceAnnots == null) {
+          mySymbolsToForceAnnots = mutable.LinkedHashSet.empty
+        }
+        mySymbolsToForceAnnots += sym
+      }
+    }
+
+    /** Force any lazy annotations collected from declaration statements directly in this scope.
+     *
+     *  It is important to call this *after* indexing statements in a scope, otherwise calling
+     *  [[ownertree.findOwner]] can fail, this is because [[ownertree.findOwner]] cannot traverse a definition tree at
+     *  a given address before a symbol has been registered to that address.
+     */
+    private[ContextOps] def forceAnnotations(): Unit = {
+      if (mySymbolsToForceAnnots != null) {
+        val toForce = mySymbolsToForceAnnots
+        mySymbolsToForceAnnots = null
+        for (sym <- toForce) {
+          log(s"!!! forcing annotations on ${showSym(sym)}")
+          analyseAnnotations(sym)
+        }
+        assert(mySymbolsToForceAnnots == null, "more symbols added while forcing")
+      }
+    }
+
   }
 
   final class FreshContext(val owner: Symbol, val outer: Context, val mode: TastyMode) extends Context {

--- a/src/compiler/scala/tools/tasty/ErasedTypeRef.scala
+++ b/src/compiler/scala/tools/tasty/ErasedTypeRef.scala
@@ -25,6 +25,7 @@ case class ErasedTypeRef(qualifiedName: TypeName, arrayDims: Int) {
     val qualified = qualifiedName.source
     "[" * arrayDims + (if (qualifiedName.toTermName.isObjectName) s"object $qualified" else qualified)
   }
+  def encode: ErasedTypeRef = ErasedTypeRef(TastyName.deepEncode(qualifiedName).toTypeName, arrayDims)
 }
 
 object ErasedTypeRef {

--- a/test/tasty/neg-isolated/src-2/TestAnnotated.check
+++ b/test/tasty/neg-isolated/src-2/TestAnnotated.check
@@ -1,10 +1,10 @@
-TestAnnotated_fail.scala:5: error: can't find type required by a member of package tastytest: tastytest.annot; perhaps it is missing from the classpath.
+TestAnnotated_fail.scala:5: error: can't find type required by package tastytest: tastytest.annot; perhaps it is missing from the classpath.
   def test1 = new Annotated {} // error: can't find type required by a member of package tastytest: tastytest.annot
                   ^
-TestAnnotated_fail.scala:6: error: could not find class tastytest.Parent whilst reading annotation of trait PublicAnnotated; perhaps it is missing from the classpath.
+TestAnnotated_fail.scala:6: error: can't find type required by parameter parent in class tastytest.publicAnnot: tastytest.Parent; perhaps it is missing from the classpath.
   def test2 = new PublicAnnotated {} // error: could not find class tastytest.Parent
                   ^
-TestAnnotated_fail.scala:7: error: could not find class tastytest.<<< whilst reading annotation of trait SymbollicAnnotated; perhaps it is missing from the classpath.
+TestAnnotated_fail.scala:7: error: can't find type required by parameter parent in class tastytest.symbollicAnnot: tastytest.<<<; perhaps it is missing from the classpath.
   def test3 = new SymbollicAnnotated {} // error: could not find class tastytest.<<<
                   ^
 3 errors

--- a/test/tasty/neg-isolated/src-2/TestChildren.check
+++ b/test/tasty/neg-isolated/src-2/TestChildren.check
@@ -1,7 +1,7 @@
-TestChildren_fail.scala:5: error: can't find type in parents of class Child: tastytest.Parent; perhaps it is missing from the classpath.
+TestChildren_fail.scala:5: error: can't find type in parents of class tastytest.Child: tastytest.Parent; perhaps it is missing from the classpath.
   def test1 = new Child
                   ^
-TestChildren_fail.scala:6: error: can't find type in parents of object Module: tastytest.Parent; perhaps it is missing from the classpath.
+TestChildren_fail.scala:6: error: can't find type in parents of object tastytest.Module: tastytest.Parent; perhaps it is missing from the classpath.
   def test2 = Module
       ^
 2 errors

--- a/test/tasty/neg-isolated/src-2/TestMethodDeps.check
+++ b/test/tasty/neg-isolated/src-2/TestMethodDeps.check
@@ -1,4 +1,4 @@
-TestMethodDeps_fail.scala:5: error: can't find type tastytest.Parent while unpickling method parent; perhaps it is missing from the classpath.
+TestMethodDeps_fail.scala:5: error: can't find type required by method parent in object tastytest.MethodDeps: tastytest.Parent; perhaps it is missing from the classpath.
   def test = MethodDeps.parent
                         ^
 1 error

--- a/test/tasty/neg/src-2/TestCompiletimeQuoteType.check
+++ b/test/tasty/neg/src-2/TestCompiletimeQuoteType.check
@@ -1,4 +1,4 @@
-TestCompiletimeQuoteType_fail.scala:4: error: can't find type scala.AnyKind while unpickling type T; perhaps it is missing from the classpath.
+TestCompiletimeQuoteType_fail.scala:4: error: can't find type required by type parameter T in class scala.quoted.Type: scala.AnyKind; perhaps it is missing from the classpath.
   def test = CompiletimeQuoteType.f[Int]
                                    ^
 1 error

--- a/test/tasty/pos/src-2/tastytest/TestAnnotated.scala
+++ b/test/tasty/pos/src-2/tastytest/TestAnnotated.scala
@@ -8,4 +8,8 @@ object TestAnnotated {
     o.foo
   }
   def test4 = new ParameterizedAnnotated(23).foo
+  def test5 = {
+    val o = new OuterAnnotated {}
+    o.foo
+  }
 }

--- a/test/tasty/pos/src-2/tastytest/TestAnnotated.scala
+++ b/test/tasty/pos/src-2/tastytest/TestAnnotated.scala
@@ -3,4 +3,9 @@ package tastytest
 object TestAnnotated {
   def test1 = new Annotated {}
   def test2 = new RootAnnotated {}
+  def test3 = {
+    val o = new OuterClassAnnotated {}
+    o.foo
+  }
+  def test4 = new ParameterizedAnnotated(23).foo
 }

--- a/test/tasty/pos/src-3/tastytest/Annotated.scala
+++ b/test/tasty/pos/src-3/tastytest/Annotated.scala
@@ -17,3 +17,8 @@ class ParameterizedAnnotated(@basicAnnot(ParameterizedAnnotated.value) x: Int) {
 object ParameterizedAnnotated {
   final val value = 23
 }
+
+trait OuterAnnotated extends OuterTrait {
+  @innerAnnot(new Inner)
+  def foo = 1
+}

--- a/test/tasty/pos/src-3/tastytest/Annotated.scala
+++ b/test/tasty/pos/src-3/tastytest/Annotated.scala
@@ -5,3 +5,15 @@ trait Annotated
 
 @rootAnnot(1)
 trait RootAnnotated
+
+trait OuterClassAnnotated extends OuterClass {
+  @basicAnnot(xyz)
+  def foo = 1
+}
+
+class ParameterizedAnnotated(@basicAnnot(ParameterizedAnnotated.value) x: Int) {
+  def foo = x
+}
+object ParameterizedAnnotated {
+  final val value = 23
+}

--- a/test/tasty/pos/src-3/tastytest/OuterClass.scala
+++ b/test/tasty/pos/src-3/tastytest/OuterClass.scala
@@ -1,0 +1,7 @@
+package tastytest
+
+class OuterClass {
+
+  final val xyz = "xyz"
+
+}

--- a/test/tasty/pos/src-3/tastytest/OuterTrait.scala
+++ b/test/tasty/pos/src-3/tastytest/OuterTrait.scala
@@ -1,0 +1,9 @@
+package tastytest
+
+trait OuterTrait {
+
+  final class Inner
+
+  final class innerAnnot(inner: Inner) extends scala.annotation.StaticAnnotation
+
+}

--- a/test/tasty/pos/src-3/tastytest/basicAnnot.scala
+++ b/test/tasty/pos/src-3/tastytest/basicAnnot.scala
@@ -1,0 +1,3 @@
+package tastytest
+
+final class basicAnnot[T](member: T) extends scala.annotation.StaticAnnotation

--- a/test/tasty/run/pre/tastytest/package.scala
+++ b/test/tasty/run/pre/tastytest/package.scala
@@ -10,7 +10,7 @@ package object tastytest {
 
   object Macros {
 
-    def hasStaticAnnotImpl[T, A](c: Context)(implicit T: c.WeakTypeTag[T], A: c.WeakTypeTag[A]) : c.Expr[Boolean] = {
+    def hasStaticAnnotImpl[T, A](c: Context)(implicit T: c.WeakTypeTag[T], A: c.WeakTypeTag[A]): c.Expr[Boolean] = {
       import c.universe._
       if (weakTypeOf[T].members.filter(_.isMethod).exists(_.annotations.exists(_.tree.tpe =:= weakTypeOf[A]))) {
         c.Expr[Boolean](q"true")


### PR DESCRIPTION
Before this, inherited members may not be visible at the point of forcing the annotation
on a definition in the template.

Also moved symbol cache to the initial context so that child contexts all pass to the same
cache.

Inner classes can not be found with Mirror getRequiredClass, so
we should have another way to compare types to signatures, this
proposes to instead convert method signatures to
Signature[ErasedTypeRef]